### PR TITLE
Update to alpine version 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.10
 
 MAINTAINER pstauffer@confirm.ch
 


### PR DESCRIPTION
Update base image to alpine 3.10. Creates image with Curl 7.66.0-r0  instead of Curl 7.61.1-r3